### PR TITLE
FIX: error Series.iteritems()

### DIFF
--- a/chapter1/01-chipotle-eda.ipynb
+++ b/chapter1/01-chipotle-eda.ipynb
@@ -477,7 +477,7 @@
    "source": [
     "# 가장 많이 주문한 item : top 10을 출력합니다.\n",
     "item_count = chipo['item_name'].value_counts()[:10]\n",
-    "for idx, (val, cnt) in enumerate(item_count.iteritems(), 1):\n",
+    "for idx, (val, cnt) in enumerate(item_count.items(), 1):\n",
     "    print(\"Top\", idx, \":\", val, cnt)"
    ]
   },


### PR DESCRIPTION
Removed deprecated Series.iteritems()... use obj.items instead. (from v2.0.0 release notes) 

Resolves: use items()

See also: iteritems was removed in 2.0.0 by GH45321.